### PR TITLE
fix(style): add custom style for 大会员 member profile page.

### DIFF
--- a/src/preload/page/space.js
+++ b/src/preload/page/space.js
@@ -24,7 +24,8 @@ export function style() {
   // language=SCSS
   AddStyle(`
 		.index__banner__M-space-banner- img,
-		.index__exp__M-space-info- {
+		.index__exp__M-space-info-,
+        .index__call__M-space-info- {
 			display: none !important;
 		}
 		.index__personal__M-space-personal- {
@@ -38,6 +39,10 @@ export function style() {
 			top: -4rem !important;
 			border: 3px solid #fff;
 			box-shadow: 0 4px 8px rgba(0, 0, 0, .1);
+		}
+        .index__big__M-space-info- {
+		    left: 9rem !important;
+		    top: -1.8rem !important;
 		}
 		.index__divider__M-space- {
 			background: #f25d8e;

--- a/src/preload/page/space.js
+++ b/src/preload/page/space.js
@@ -25,7 +25,7 @@ export function style() {
   AddStyle(`
 		.index__banner__M-space-banner- img,
 		.index__exp__M-space-info-,
-        .index__call__M-space-info- {
+		.index__call__M-space-info- {
 			display: none !important;
 		}
 		.index__personal__M-space-personal- {
@@ -40,9 +40,9 @@ export function style() {
 			border: 3px solid #fff;
 			box-shadow: 0 4px 8px rgba(0, 0, 0, .1);
 		}
-        .index__big__M-space-info- {
-		    left: 9rem !important;
-		    top: -1.8rem !important;
+		.index__big__M-space-info- {
+			left: 9rem !important;
+			top: -1.8rem !important;
 		}
 		.index__divider__M-space- {
 			background: #f25d8e;


### PR DESCRIPTION
Currently the 大会员 badge is rendered incorrectly on member profile pages (see screenshot below).
<img width="487" alt="original" src="https://user-images.githubusercontent.com/1730305/34548209-a1854518-f0b5-11e7-9be2-a217f7e68de8.png">
This PR proposes the following style rule change to reflect the original styling in the electron app.
<img width="487" alt="fixed" src="https://user-images.githubusercontent.com/1730305/34548269-f08d978c-f0b5-11e7-8ce8-9e16ad3ffc6d.png">
